### PR TITLE
feat(playbook): lock kernel version for ws-01-linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: galaxy ping facts bootstrap-linux bootstrap-windows switch-linux switch-windows keepalive keyscan
+.PHONY: galaxy ping facts bootstrap-linux bootstrap-windows switch-linux switch-windows keepalive keyscan lock-kernel
 
 galaxy:
 	ansible-galaxy collection install -r requirements.yml
@@ -26,4 +26,7 @@ switch-windows:
 	ansible-playbook -i inventory/hosts.yaml playbooks/switch-to-windows.yml
 
 keepalive:
-	ansible-playbook -i inventory/hosts.yaml playbooks/keepalive.yml
+        ansible-playbook -i inventory/hosts.yaml playbooks/keepalive.yml
+
+lock-kernel:
+        ansible-playbook -i inventory/hosts.yaml playbooks/lock-kernel.yml

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ make bootstrap-windows
 # 8) 双向切换演练
 make switch-linux     # Windows → Linux
 make switch-windows   # Linux → Windows
+
+# 9) 锁定 ws-01-linux 当前内核版本（防止自动升级）
+make lock-kernel
 ```
 
 > 如遇到等待时间不够，可按机器实际速度把 `switch-*.yml` 中 `timeout` 加大。

--- a/playbooks/lock-kernel.yml
+++ b/playbooks/lock-kernel.yml
@@ -1,0 +1,31 @@
+- name: Lock kernel version on ws-01-linux
+  hosts: ws-01-linux
+  become: true
+  gather_facts: true
+
+  tasks:
+    - name: Hold current kernel packages
+      ansible.builtin.shell: |
+        set -e
+        KERN="{{ ansible_kernel }}"
+        for pkg in linux-image-$KERN linux-headers-$KERN linux-modules-$KERN linux-modules-extra-$KERN; do
+          if dpkg -s "$pkg" >/dev/null 2>&1; then
+            apt-mark hold "$pkg"
+          fi
+        done
+      args:
+        executable: /bin/bash
+      register: hold_result
+      changed_when: "'set on hold' in hold_result.stdout"
+
+    - name: List held kernel packages
+      ansible.builtin.shell: |
+        apt-mark showhold | grep "linux-.*{{ ansible_kernel }}" || true
+      args:
+        executable: /bin/bash
+      changed_when: false
+      register: held_pkgs
+
+    - name: Display held kernel packages
+      ansible.builtin.debug:
+        msg: "Held packages: {{ held_pkgs.stdout_lines }}"


### PR DESCRIPTION
## Summary
- add playbook to hold current kernel packages on ws-01-linux
- document and expose lock-kernel make target

## Testing
- `ansible-playbook -i inventory/hosts.yaml playbooks/lock-kernel.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_68bccabe659c832aa04f4085d48e79d6