### PR TITLE
fix: correct template path in Windows bootstrap playbook

### DIFF
--- a/playbooks/bootstrap-windows.yml
+++ b/playbooks/bootstrap-windows.yml
@@ -10,7 +10,7 @@
 
     - name: Deploy to-linux.ps1
       ansible.builtin.template:
-        src: templates/to-linux.ps1.j2
+        src: ../templates/to-linux.ps1.j2
         dest: "C:\\ops\\to-linux.ps1"
         mode: '0644'
         newline_sequence: "\r\n"


### PR DESCRIPTION
## Summary
- point Windows bootstrap playbook at correct `to-linux.ps1` template

## Testing
- `ansible-playbook --syntax-check playbooks/bootstrap-windows.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bf3c93a670832aa6c0963319570940