### PR TITLE
Use Windows-native modules for Windows hosts

### DIFF
--- a/playbooks/bootstrap-windows.yml
+++ b/playbooks/bootstrap-windows.yml
@@ -9,14 +9,13 @@
         state: directory
 
     - name: Deploy to-linux.ps1
-      ansible.builtin.template:
+      ansible.windows.win_template:
         src: ../templates/to-linux.ps1.j2
         dest: "C:\\ops\\to-linux.ps1"
-        mode: '0644'
         newline_sequence: "\r\n"
 
     - name: Enable and start OpenSSH Server
-      ansible.builtin.shell: |
+      ansible.windows.win_shell: |
         powershell -NoProfile -Command "
           if (-not (Get-Service sshd -ErrorAction SilentlyContinue)) {
             Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 | Out-Null
@@ -26,7 +25,7 @@
         "
 
     - name: Ensure firewall rule for TCP 22 exists
-      ansible.builtin.shell: |
+      ansible.windows.win_shell: |
         powershell -NoProfile -Command "
           if (-not (Get-NetFirewallRule -DisplayName 'OpenSSH Server (TCP 22)' -ErrorAction SilentlyContinue)) {
             New-NetFirewallRule -DisplayName 'OpenSSH Server (TCP 22)' -Direction Inbound -Protocol TCP -LocalPort 22 -Action Allow -Profile Any | Out-Null

--- a/playbooks/facts.yml
+++ b/playbooks/facts.yml
@@ -11,7 +11,7 @@
   gather_facts: false
   tasks:
     - name: Hostname
-      ansible.builtin.command: hostname
+      ansible.windows.win_command: hostname
       register: h
     - name: Show
       ansible.builtin.debug:

--- a/playbooks/keepalive.yml
+++ b/playbooks/keepalive.yml
@@ -24,7 +24,7 @@
   gather_facts: false
   tasks:
     - name: Ensure sshd running
-      ansible.builtin.shell: |
+      ansible.windows.win_shell: |
         powershell -NoProfile -Command "
           Set-Service -Name sshd -StartupType Automatic
           if ((Get-Service sshd).Status -ne 'Running') { Start-Service sshd }

--- a/playbooks/ping.yml
+++ b/playbooks/ping.yml
@@ -10,4 +10,4 @@
   gather_facts: false
   tasks:
     - name: whoami
-      ansible.builtin.command: whoami
+      ansible.windows.win_command: whoami

--- a/playbooks/switch-to-linux.yml
+++ b/playbooks/switch-to-linux.yml
@@ -8,11 +8,9 @@
 
   tasks:
     - name: Trigger to-linux.ps1 on Windows
-      ansible.builtin.shell: |
-        powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "{{ ps_file }}"
+      ansible.windows.win_shell: |
+        Start-Process -FilePath powershell.exe -ArgumentList '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "{{ ps_file }}"' -WindowStyle Hidden
       delegate_to: "{{ win_host }}"
-      async: 30
-      poll: 0
 
     - name: Wait for Windows SSH to drop
       ansible.builtin.wait_for:

--- a/playbooks/switch-to-windows.yml
+++ b/playbooks/switch-to-windows.yml
@@ -49,5 +49,5 @@
           delegate_to: localhost
 
     - name: Confirm Windows reachable (whoami)
-      ansible.builtin.command: whoami
+      ansible.windows.win_command: whoami
       delegate_to: "{{ win_host }}"


### PR DESCRIPTION
## Summary
- replace generic modules with `win_*` equivalents for Windows hosts
- ensure Windows playbooks use `win_shell`, `win_command`, and `win_template`
- run Windows switch script via `Start-Process` to avoid Python async wrapper
- remove unsupported `mode` parameter from `win_template`

## Testing
- `ansible-playbook -i inventory/hosts.yaml playbooks/bootstrap-windows.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_68bf72c984c4832a892e0785aec3780c