### PR TITLE
Fix broken Ansible playbooks

### DIFF
--- a/playbooks/ping.yml
+++ b/playbooks/ping.yml
@@ -9,7 +9,5 @@
   hosts: windows
   gather_facts: false
   tasks:
- codex/review-ansible-playbooks-for-compatibility-issues-ggqmkz
     - name: Whoami
-
       ansible.windows.win_command: whoami

--- a/playbooks/switch-to-linux.yml
+++ b/playbooks/switch-to-linux.yml
@@ -1,12 +1,10 @@
- codex/review-ansible-playbooks-for-compatibility-issues-ggqmkz
 - name: Windows → Linux (one-time boot to Ubuntu via bcdedit), orchestrated from controllers
- main
   hosts: controllers
   gather_facts: false
   vars:
     win_host: ws-01-win
     linux_host: ws-01-linux
-    ps_file: 'C:\ops\to-linux.ps1'
+    ps_file: 'C:\\ops\\to-linux.ps1'
 
   tasks:
     - name: Trigger to-linux.ps1 on Windows

--- a/playbooks/switch-to-windows.yml
+++ b/playbooks/switch-to-windows.yml
@@ -1,6 +1,4 @@
- codex/review-ansible-playbooks-for-compatibility-issues-ggqmkz
 - name: Linux → Windows (efibootmgr BootNext), orchestrated from controllers
- main
   hosts: controllers
   gather_facts: false
   vars:
@@ -8,12 +6,9 @@
     linux_host: ws-01-linux
 
   tasks:
- codex/review-ansible-playbooks-for-compatibility-issues-ggqmkz
-
     - name: Trigger to-windows.sh on Linux host
       ansible.builtin.shell: |
         bash -lc "/home/{{ hostvars[linux_host].ansible_user }}/ops/to-windows.sh"
-
       delegate_to: "{{ linux_host }}"
       async: 30
       poll: 0
@@ -27,7 +22,6 @@
         timeout: 240
       delegate_to: localhost
 
- codex/review-ansible-playbooks-for-compatibility-issues-q8bq6c
     - name: Wait for Windows SSH to appear (first window)
       ansible.builtin.wait_for:
         host: "{{ hostvars[win_host].ansible_host }}"
@@ -56,7 +50,5 @@
           delegate_to: localhost
 
     - name: Confirm Windows reachable (whoami)
- codex/review-ansible-playbooks-for-compatibility-issues-ggqmkz
- main
       ansible.windows.win_command: whoami
       delegate_to: "{{ win_host }}"


### PR DESCRIPTION
## Summary
- remove stray codex review markers from ping playbook
- restore valid YAML for OS-switch playbooks

## Testing
- `ansible-playbook --syntax-check playbooks/ping.yml`
- `ansible-playbook --syntax-check playbooks/switch-to-linux.yml`
- `ansible-playbook --syntax-check playbooks/switch-to-windows.yml`
- `ansible-lint playbooks/ping.yml playbooks/switch-to-linux.yml playbooks/switch-to-windows.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bf8af6d810832aa7076d51ef0f2f23