### PR TITLE
Add observability stack deployment playbook

### DIFF
--- a/playbooks/bootstrap-linux.yml
+++ b/playbooks/bootstrap-linux.yml
@@ -19,7 +19,7 @@
       ansible.builtin.package:
         name: snapd
         state: present
-      ignore_errors: true
+      failed_when: false
 
     - name: Enable and start tailscale (snap) if available
       ansible.builtin.shell: |
@@ -58,6 +58,7 @@
       args:
         executable: /bin/bash
       register: paths
+      changed_when: false
 
     - name: Set facts for sudoers
       ansible.builtin.set_fact:
@@ -75,9 +76,12 @@
         validate: "/usr/sbin/visudo -cf %s"
 
     - name: Test sudo -n efibootmgr
-      ansible.builtin.shell: "sudo -n {{ efibootmgr_path }} -v | head -n1"
+      ansible.builtin.shell: |
+        set -o pipefail
+        sudo -n {{ efibootmgr_path }} -v | head -n1
       args:
         executable: /bin/bash
+      changed_when: false
 
     - name: (Optional) Sunshine autostart for current user
       become: false

--- a/playbooks/deploy-observability-stack.yml
+++ b/playbooks/deploy-observability-stack.yml
@@ -1,0 +1,148 @@
+- name: Deploy observability services on controller
+  hosts: controllers
+  become: true
+  vars:
+    templates_dir: "{{ playbook_dir }}/../templates"
+  tasks:
+    - name: Ensure required packages are installed
+      ansible.builtin.apt:
+        name:
+          - apt-transport-https
+          - software-properties-common
+          - wget
+          - gpg
+        state: present
+        update_cache: true
+
+    - name: Create keyring directory
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: '0755'
+
+    - name: Download Grafana GPG key
+      ansible.builtin.get_url:
+        url: https://apt.grafana.com/gpg.key
+        dest: /etc/apt/keyrings/grafana.asc
+        mode: '0644'
+
+    - name: Convert Grafana GPG key to keyring
+      ansible.builtin.command:
+        cmd: gpg --dearmor -o /etc/apt/keyrings/grafana.gpg /etc/apt/keyrings/grafana.asc
+        creates: /etc/apt/keyrings/grafana.gpg
+
+    - name: Add Grafana APT repository
+      ansible.builtin.apt_repository:
+        repo: "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main"
+        state: present
+        filename: grafana
+
+    - name: Install Loki and Grafana
+      ansible.builtin.apt:
+        name:
+          - loki
+          - grafana
+        state: present
+        update_cache: true
+
+    - name: Ensure Loki service is enabled and started
+      ansible.builtin.systemd:
+        name: loki
+        state: started
+        enabled: true
+
+    - name: Create Grafana datasource directory
+      ansible.builtin.file:
+        path: /etc/grafana/provisioning/datasources
+        state: directory
+        mode: '0755'
+
+    - name: Configure Grafana Loki datasource
+      ansible.builtin.template:
+        src: "{{ templates_dir }}/grafana-datasource-loki.yml.j2"
+        dest: /etc/grafana/provisioning/datasources/loki.yml
+        mode: '0644'
+      notify: Restart Grafana
+
+    - name: Ensure Grafana service is enabled and started
+      ansible.builtin.systemd:
+        name: grafana-server
+        state: started
+        enabled: true
+
+  handlers:
+    - name: Restart Grafana
+      ansible.builtin.systemd:
+        name: grafana-server
+        state: restarted
+
+- name: Deploy Grafana Alloy on Linux hosts
+  hosts: linux,controllers
+  become: true
+  vars:
+    loki_host: "{{ hostvars['ctrl-linux-01'].ansible_host | default('ctrl-linux-01') }}"
+    templates_dir: "{{ playbook_dir }}/../templates"
+  tasks:
+    - name: Ensure required packages are installed
+      ansible.builtin.apt:
+        name:
+          - apt-transport-https
+          - software-properties-common
+          - wget
+          - gpg
+        state: present
+        update_cache: true
+
+    - name: Create keyring directory
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: '0755'
+
+    - name: Download Grafana GPG key
+      ansible.builtin.get_url:
+        url: https://apt.grafana.com/gpg.key
+        dest: /etc/apt/keyrings/grafana.asc
+        mode: '0644'
+
+    - name: Convert Grafana GPG key to keyring
+      ansible.builtin.command:
+        cmd: gpg --dearmor -o /etc/apt/keyrings/grafana.gpg /etc/apt/keyrings/grafana.asc
+        creates: /etc/apt/keyrings/grafana.gpg
+
+    - name: Add Grafana APT repository
+      ansible.builtin.apt_repository:
+        repo: "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main"
+        state: present
+        filename: grafana
+
+    - name: Install Grafana Alloy
+      ansible.builtin.apt:
+        name: alloy
+        state: present
+        update_cache: true
+
+    - name: Create Alloy configuration directory
+      ansible.builtin.file:
+        path: /etc/alloy
+        state: directory
+        mode: '0755'
+
+    - name: Deploy Alloy configuration
+      ansible.builtin.template:
+        src: "{{ templates_dir }}/config.alloy.j2"
+        dest: /etc/alloy/config.alloy
+        mode: '0644'
+      notify: Restart Alloy
+
+    - name: Ensure Alloy service is enabled and started
+      ansible.builtin.systemd:
+        name: alloy
+        state: started
+        enabled: true
+
+  handlers:
+    - name: Restart Alloy
+      ansible.builtin.systemd:
+        name: alloy
+        state: restarted

--- a/playbooks/repair-broken-kernel.yml
+++ b/playbooks/repair-broken-kernel.yml
@@ -2,29 +2,23 @@
   hosts: ws-01-linux
   become: true
   tasks:
-    - name: Force remove broken NVIDIA meta-package
-      ansible.builtin.dpkg:
-        name: linux-modules-nvidia-550-generic-hwe-24.04
-        state: absent
-        force: yes
-
-    - name: Force remove all related 6.14.0-29 packages
+    - name: Force remove all related broken packages using apt
       ansible.builtin.apt:
         name:
           - linux-image-6.14.0-29-generic
           - linux-headers-6.14.0-29-generic
           - linux-modules-nvidia-550-6.14.0-29-generic
+          - linux-modules-nvidia-550-generic-hwe-24.04
           - linux-signatures-nvidia-6.14.0-29-generic
         state: absent
-        autoremove: yes
-        purge: yes
-        force: yes
+        autoremove: true
+        purge: true
 
-    - name: Run 'apt --fix-broken install'
+    - name: Run 'apt --fix-broken install' to ensure system health
       ansible.builtin.apt:
-        fix_broken: yes
+        fix_broken: true
 
-    - name: Final update to GRUB
+    - name: Final update to GRUB to remove old entries
       ansible.builtin.command:
         cmd: update-grub
       changed_when: false

--- a/playbooks/switch-to-linux.yml
+++ b/playbooks/switch-to-linux.yml
@@ -6,7 +6,7 @@
   gather_facts: false
 
   vars:
-    win_host:   ws-01-win
+    win_host: ws-01-win
     linux_host: ws-01-linux
 
   tasks:

--- a/playbooks/switch-to-windows.yml
+++ b/playbooks/switch-to-windows.yml
@@ -6,7 +6,7 @@
   gather_facts: false
 
   vars:
-    win_host:   ws-01-win
+    win_host: ws-01-win
     linux_host: ws-01-linux
 
     wol_mac: "9C:6B:00:05:B4:16"
@@ -19,6 +19,7 @@
       delegate_to: "{{ linux_host }}"
       async: 30
       poll: 0
+      changed_when: false
 
     - name: Wait for Linux SSH(22) to drop
       ansible.builtin.wait_for:
@@ -42,7 +43,8 @@
       when: wait1 is failed or (wait1 is defined and (wait1.failed | default(false)))
       block:
         - name: Try 'tailscale wake' first (ignore errors)
-          ansible.builtin.shell: "tailscale wake {{ wol_mac }}"
+          ansible.builtin.command:
+            cmd: "tailscale wake {{ wol_mac }}"
           register: tswake
           changed_when: false
           failed_when: false
@@ -67,3 +69,4 @@
       ansible.builtin.command:
         cmd: hostname
       delegate_to: "{{ win_host }}"
+      changed_when: false

--- a/templates/config.alloy.j2
+++ b/templates/config.alloy.j2
@@ -1,16 +1,11 @@
-// templates/config.alloy.j2
-prometheus.scrape "self" {
-  targets = [
-    {"__address__" = "127.0.0.1:12345", "instance" = "alloy-itself"},
-  ]
-  forward_to = [prometheus.remote_write.local.receiver]
+# templates/config.alloy.j2
+loki.source.journal "system" {
+  labels = {job = "systemd-journal"}
+  forward_to = [loki.write.default.receiver]
 }
 
-prometheus.remote_write "local" {
+loki.write "default" {
   endpoint {
-    url = "http://localhost:9090/api/v1/write" // This is a placeholder, as we are writing to a local WAL.
-  }
-  wal {
-    path = "/tmp/alloy-wal" // Write data to a local directory for verification.
+    url = "http://{{ 'localhost' if inventory_hostname == 'ctrl-linux-01' else loki_host }}:3100/loki/api/v1/push"
   }
 }

--- a/templates/grafana-datasource-loki.yml.j2
+++ b/templates/grafana-datasource-loki.yml.j2
@@ -1,0 +1,8 @@
+# templates/grafana-datasource-loki.yml.j2
+apiVersion: 1
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://localhost:3100
+    isDefault: true


### PR DESCRIPTION
## Summary
- automate deployment of Loki, Grafana, and Alloy across hosts
- provision Grafana with a Loki datasource and journald log collection via Alloy
- replace dpkg usage with apt in repair-broken-kernel playbook for ansible-lint compliance
- refactor observability playbook to fetch Grafana key with modules and absolute template paths
- clean switch-to-OS and bootstrap playbooks for ansible-lint and idempotency

## Testing
- `ansible-lint playbooks/deploy-observability-stack.yml playbooks/repair-broken-kernel.yml playbooks/switch-to-linux.yml playbooks/switch-to-windows.yml playbooks/bootstrap-linux.yml playbooks/bootstrap-windows.yml`
- `ansible-playbook -i inventory/hosts.yaml playbooks/deploy-observability-stack.yml --syntax-check`
- `ansible-playbook -i inventory/hosts.yaml playbooks/repair-broken-kernel.yml --syntax-check`
- `ansible-playbook -i inventory/hosts.yaml playbooks/switch-to-linux.yml --syntax-check`
- `ansible-playbook -i inventory/hosts.yaml playbooks/switch-to-windows.yml --syntax-check`
- `ansible-playbook -i inventory/hosts.yaml playbooks/bootstrap-linux.yml --syntax-check`
- `ansible-playbook -i inventory/hosts.yaml playbooks/bootstrap-windows.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_68c63df918b0832a8bc77f365a835258