### PR TITLE
[ansible/ci] adopt recipe prefix and runner setup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.github/workflows/pr-quality-check.yml
+++ b/.github/workflows/pr-quality-check.yml
@@ -1,40 +1,44 @@
 name: Ansible PR Quality Gate
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
 
 jobs:
-  # Gate 1: 静态检查 (在云端运行，快速反馈)
-  static-analysis:
-    name: Gate 1 - Lint and Static Tests
-    runs-on: ubuntu-latest
+  gate1-static:
+    name: Gate 1 - lint & local tests
+    runs-on: [self-hosted, ansible, hardware]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Run 'make lint'
+      - uses: actions/checkout@v4
+      - name: Setup runner tools
+        run: make setup
+      - name: Run make lint
         run: make lint
-
-      - name: Run 'make test'
+      - name: Run make test
         run: make test
 
-  # Gate 2: 集成测试 (在您的真实硬件上运行)
-  integration-test:
-    name: Gate 2 - Integration Test
-    needs: static-analysis # 只有在 Gate 1 通过后才运行
-    runs-on: [self-hosted, ansible, hardware] # 使用我们新的、带标签的运行器
-
+  gate2-integration:
+    name: Gate 2 - integration (machine-verifiable)
+    needs: gate1-static
+    runs-on: [self-hosted, ansible, hardware]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup SSH Key
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
-      - name: Install Ansible dependencies
-        run: make setup # 假设 Makefile 里有 setup 目标来安装依赖
-
-      - name: Run 'make itest'
+      - uses: actions/checkout@v4
+      - name: Run make itest
         run: make itest
+      - name: Upload itest artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: itest-artifacts
+          path: artifacts/itest
+
+  deploy:
+    name: Deploy on success
+    needs: gate2-integration
+    if: needs.gate2-integration.result == 'success'
+    runs-on: [self-hosted, ansible, hardware]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy
+        run: make deploy

--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,64 @@
-.PHONY: galaxy ping facts bootstrap-linux bootstrap-windows switch-linux switch-windows keepalive keyscan lock-kernel
+.RECIPEPREFIX := >
+.PHONY: galaxy keyscan ping facts bootstrap-linux bootstrap-windows switch-linux switch-windows keepalive lock-kernel setup lint test itest deploy
 
+# Install required Ansible collections
 galaxy:
-	ansible-galaxy collection install -r requirements.yml
+> ansible-galaxy collection install -r requirements.yml
 
+# Refresh SSH host keys
 keyscan:
-	bash scripts/ssh-keyscan.sh
+> bash scripts/ssh-keyscan.sh
 
+# Basic connectivity checks
 ping:
-	ansible -i inventory/hosts.yaml linux -m ansible.builtin.ping
-	ansible -i inventory/hosts.yaml windows -m ansible.builtin.command -a "hostname"
+> ansible -i inventory/hosts.yaml linux -m ansible.builtin.ping
+> ansible -i inventory/hosts.yaml windows -m ansible.builtin.command -a "hostname"
 
+# Gather system facts
 facts:
-	ansible-playbook -i inventory/hosts.yaml playbooks/facts.yml
+> ansible-playbook -i inventory/hosts.yaml playbooks/facts.yml
 
+# Bootstrap hosts
 bootstrap-linux:
-	ansible-playbook -i inventory/hosts.yaml playbooks/bootstrap-linux.yml
+> ansible-playbook -i inventory/hosts.yaml playbooks/bootstrap-linux.yml
 
 bootstrap-windows:
-	ansible-playbook -i inventory/hosts.yaml playbooks/bootstrap-windows.yml
+> ansible-playbook -i inventory/hosts.yaml playbooks/bootstrap-windows.yml
 
+# Switch operating systems
 switch-linux:
-	ansible-playbook -i inventory/hosts.yaml playbooks/switch-to-linux.yml
+> ansible-playbook -i inventory/hosts.yaml playbooks/switch-to-linux.yml
 
 switch-windows:
-	ansible-playbook -i inventory/hosts.yaml playbooks/switch-to-windows.yml
+> ansible-playbook -i inventory/hosts.yaml playbooks/switch-to-windows.yml
 
+# Keep services alive
 keepalive:
-        ansible-playbook -i inventory/hosts.yaml playbooks/keepalive.yml
+> ansible-playbook -i inventory/hosts.yaml playbooks/keepalive.yml
 
+# Lock kernel version
 lock-kernel:
-        ansible-playbook -i inventory/hosts.yaml playbooks/lock-kernel.yml
+> ansible-playbook -i inventory/hosts.yaml playbooks/lock-kernel.yml
+
+# Runner tools setup
+setup:
+> ansible-playbook -i localhost, playbooks/runner-prepare.yml
+
+# Gate 1 - lint & static checks
+lint:
+> ansible-lint
+> yamllint .
+> ansible-playbook --syntax-check -i inventory/hosts.yaml playbooks/*.yml
+
+# Gate 1 - dry-run and idempotence
+test:
+> ansible-playbook -i inventory/hosts.yaml playbooks/facts.yml --check --diff
+> ansible-playbook -i inventory/hosts.yaml playbooks/facts.yml
+
+# Gate 2 - integration tests
+itest:
+> ansible-playbook -i inventory/hosts.yaml playbooks/tests/verify_observability.yml
+
+# Deploy observability stack
+deploy:
+> ansible-playbook -i inventory/hosts.yaml playbooks/deploy-observability-stack.yml

--- a/playbooks/runner-prepare.yml
+++ b/playbooks/runner-prepare.yml
@@ -1,0 +1,40 @@
+---
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Ensure Python and pip are present
+      become: true
+      ansible.builtin.package:
+        name:
+          - python3
+          - python3-pip
+        state: present
+
+    - name: Install Ansible tooling
+      become: true
+      ansible.builtin.pip:
+        name:
+          - ansible-core
+          - ansible-lint
+          - yamllint
+        state: latest
+
+    - name: Ensure artifacts directory exists
+      ansible.builtin.file:
+        path: artifacts/test
+        state: directory
+        mode: '0755'
+
+    - name: Collect tool versions
+      ansible.builtin.shell: |
+        set -e
+        ansible --version | head -1
+        ansible-lint --version
+        yamllint --version
+      register: tools
+      changed_when: false
+
+    - name: Write tool versions
+      ansible.builtin.copy:
+        dest: artifacts/test/tools_versions.txt
+        content: "{{ tools.stdout }}"


### PR DESCRIPTION
## Summary
- switch Makefile to `>` recipe prefix and define golden path targets
- add runner preparation playbook and `make setup`
- run Golden Path on self-hosted runner via new workflow

## Testing Done
- `make setup` *(fails: ansible-playbook: No such file or directory)*
- `make lint` *(fails: ansible-lint: No such file or directory)*
- `make test` *(fails: ansible-playbook: No such file or directory)*
- `make itest` *(fails: ansible-playbook: No such file or directory)*
- `make deploy` *(fails: ansible-playbook: No such file or directory)*

<!-- codex-meta v1
task_id: BUILD-MAKEFIX
domain: homeops
iteration: 1
network_mode: off
-->

<!-- codex-meta v1
task_id: RUNNER-TOOLS
domain: homeops
iteration: 1
network_mode: off
-->

<!-- codex-meta v1
task_id: CI-REPLACE
domain: homeops
iteration: 1
network_mode: off
-->

------
https://chatgpt.com/codex/tasks/task_e_68c67391c42c832ab06690f24c1d2ea9