### PR TITLE
[ansible/docs] add Gate2 verification spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@
 - 建议输出：`artifacts/test/` 收集检查报告。
 
 ### 3.3 `make itest` — 集成测试（Gate 2）
+- Gate2 参考 docs/verification-spec.md
 - 目的：在自托管 Runner 上对目标主机做 **真实部署前的可验收断言**（或蓝绿/影子环境）。
 - 应执行：`playbooks/tests/verify_observability.yml`（见 §5 验收断言）。
 - 失败处理：自动收集 **最近 200 行服务日志**、**关键 API 响应** 至 `artifacts/itest/` 并作为 CI 工件。

--- a/docs/verification-spec.md
+++ b/docs/verification-spec.md
@@ -1,65 +1,77 @@
-# Observability Stack Verification Spec (Gate 2)
+Verification Spec — Observability Stack (Alloy + Loki + Grafana)
+目的：定义 Gate 2 / make itest 的唯一判分标准与证据口径。
+适用仓库：HomeOps（控制器与 Runner：ctrl-linux-01）。
+关联契约：AGENTS.md / Makefile（lint → test → itest → deploy）。
 
-**Scope**: Validate the Loki + Grafana + Alloy stack deployed on the controller `ctrl-linux-01` and ingestion from all Linux nodes (e.g., `ctrl-linux-01`, `ws-01-linux`).
+0. 前置条件（Pre-req & Env）
+控制器与自托管 Runner：ctrl-linux-01（标签：self-hosted, ansible, hardware）。
 
-## Acceptance Criteria (machine-verifiable)
+Inventory 分组：
 
-### A. Services are installed and running on controller
-- `loki` systemd service is **active (running)** and **enabled**.
-- `grafana-server` systemd service is **active (running)** and **enabled**.
-- `alloy` systemd service is **active (running)** and **enabled** on target hosts (`controllers` + `linux`).
+controllers: ctrl-linux-01
 
-### B. Endpoints are reachable on controller
-- Loki readiness endpoint responds with HTTP **200**: `http://127.0.0.1:3100/ready`
-- Grafana responds on port **3000**; `/api/health` should return **200** (OK) or **401** (Unauthorized), both indicate reachability without credentials.
+linux: ws-01-linux, ctrl-linux-01
 
-### C. Logs are flowing
-- A query against Loki for `{job="systemd-journal"}` returns **at least 1** entry from **each** of:
-  - `ctrl-linux-01`
-  - `ws-01-linux`
-- Freshness: the newest entry from each host is **≤ 10 minutes** old.
+端口：Loki 3100，Grafana 3000（可通过变量覆盖）。
 
-## Reference Implementation Hints (Ansible)
-A real `playbooks/tests/verify_observability.yml` SHOULD:
-1. **Check systemd** status and enablement
-   ```yaml
-   - ansible.builtin.service_facts:
-   - ansible.builtin.assert:
-       that:
-         - "'loki.service' in ansible_facts.services and ansible_facts.services['loki.service'].state == 'running'"
-         - "'grafana-server.service' in ansible_facts.services and ansible_facts.services['grafana-server.service'].state == 'running'"
-   ```
-2. **Probe endpoints**
-   ```yaml
-   - ansible.builtin.uri:
-       url: "http://127.0.0.1:3100/ready"
-       status_code: 200
-   - ansible.builtin.uri:
-       url: "http://127.0.0.1:3000/api/health"
-       status_code: [200, 401]
-   ```
-3. **Query Loki for journal entries**
-   - Either call the Loki HTTP API:
-     ```yaml
-     - ansible.builtin.uri:
-         url: "http://127.0.0.1:3100/loki/api/v1/query"
-         method: GET
-         return_content: true
-         params:
-           query: '{job="systemd-journal"}'
-     ```
-   - Or shell out to `journalctl` as a minimal smoke:
-     ```yaml
-     - ansible.builtin.command: journalctl -n 1 -o short-iso
-       register: jctl
-     - ansible.builtin.assert:
-         that: jctl.stdout != ""
-     ```
-4. **Collect artifacts** (logs, `systemctl status` outputs, API responses) under `artifacts/itest/` for CI review.
+Secrets（由项目负责人配置到 Runner/CI）：
 
-## Scoring
-- Gate 2 passes if **A + B + C** all hold.
-- If any check fails, the playbook MUST `failed_when: true` with clear messages and write relevant outputs to `artifacts/itest/`.
+GRAFANA_ADMIN_USER / GRAFANA_ADMIN_PASSWORD 用于 Grafana API。
 
----
-**Note**: The current repository includes a placeholder `playbooks/tests/verify_observability.yml` so CI can run. Replace it per this spec in Issue #27.
+1. 金路径引用
+Gate 1：make lint / make test
+
+Gate 2：make itest → 执行本规格的所有断言；失败必须收集证据到 artifacts/itest/；任何断言失败均返回非零退出码。
+
+2. 断言与证据（Assertions & Evidence）
+A. 服务活性（即刻判）
+断言
+
+在 controllers 上：loki、grafana-server 为 active
+
+在 controllers, linux 上：alloy 为 active
+
+失败时证据
+
+保存最近 200 行日志：
+
+journalctl -u loki -n 200 → artifacts/itest/journal_loki.log
+
+journalctl -u grafana-server -n 200 → artifacts/itest/journal_grafana.log
+
+journalctl -u alloy -n 200 → artifacts/itest/journal_alloy.log
+
+B. 端口连通（30s 重试）
+断言
+
+ctrl-linux-01:3100（Loki）、ctrl-linux-01:3000（Grafana）TCP 可达（max 30s，退避重试）。
+
+失败时证据
+
+ss -lntp 与 iptables -S 输出 → artifacts/itest/net_diag.txt
+
+C. Grafana 健康与数据源（60s 重试）
+断言
+
+GET http://ctrl-linux-01:3000/api/health 返回 JSON 含 "database": "ok"
+
+存在名为 Loki 的数据源（/api/datasources 列表中匹配）
+
+方法与证据
+
+Ansible uri，用 GRAFANA_ADMIN_USER/PASSWORD 基本认证。
+
+响应 JSON 保存为：
+
+artifacts/itest/health.json
+
+artifacts/itest/datasources.json
+
+D. 日志功能性（Loki 查询，90s 轮询）
+断言
+
+对 http://ctrl-linux-01:3100/loki/api/v1/query_range 以表达式 {job="systemd-journal"} 在 90s 内查询到同时来自 ws-01-linux 与 ctrl-linux-01 的日志（各 ≥ 1 条）。
+
+方法与证据
+
+用 uri 轮询；保存最后一次请求与响应：artifacts/itest/loki_query.json


### PR DESCRIPTION
## Summary
- document Gate2 machine-verifiable acceptance criteria for observability stack in docs/verification-spec.md
- AGENTS already references this spec for Gate2 testing

## Testing
- `make lint` *(fails: 554 violations)*
- `make test` *(fails: ssh network is unreachable)*
- `make itest`
- `make deploy` *(fails: Loki service in unknown state)*

<!-- codex-meta v1
task_id: ISSUE-26
domain: homeops
iteration: 2
network_mode: online
-->

------
https://chatgpt.com/codex/tasks/task_e_68c67e653544832ab838dbbe2f3cc192