### PR TITLE
[ansible/langgraph] Setup ssh agent for workflow

### DIFF
--- a/playbooks/run-sealos-langgraph.yml
+++ b/playbooks/run-sealos-langgraph.yml
@@ -11,6 +11,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup SSH Key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
       - name: Install Ansible if missing
         run: |
           if ! command -v ansible-playbook >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- add the shared ssh-agent setup step so the Sealos + LangGraph workflow can authenticate to controller hosts

## Testing Done
- Not run (workflow change)

<!-- codex-meta v1
task_id: run-sealos-langgraph-ssh
domain: homeops
iteration: 1
network_mode: off
-->

------
https://chatgpt.com/codex/tasks/task_e_68f523298a54832a88d655e628028799