### PR TITLE
[ansible/workflows] Add run-sealos entry to manual runner

### DIFF
--- a/.github/workflows/run-ansible-playbook.yml
+++ b/.github/workflows/run-ansible-playbook.yml
@@ -8,8 +8,10 @@ on:
         required: true
         type: choice
         options:
+          - cleanup-boot-entries.yml
           - repair-boot-final.yml
           - deploy-alloy.yml
+          - run-sealos-langgraph.yml
         default: 'cleanup-boot-entries.yml'
 
 jobs:

--- a/playbooks/run-sealos-langgraph.yml
+++ b/playbooks/run-sealos-langgraph.yml
@@ -11,6 +11,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup SSH Key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
       - name: Install Ansible if missing
         run: |
           if ! command -v ansible-playbook >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- expose the cleanup-boot-entries and run-sealos-langgraph playbooks through the manual workflow picker so they can be invoked from Actions UI

## Testing Done
- Not run (workflow change)

<!-- codex-meta v1
task_id: run-sealos-langgraph-ssh
domain: homeops
iteration: 2
network_mode: off
-->


------
https://chatgpt.com/codex/tasks/task_e_68f523298a54832a88d655e628028799