### PR TITLE
[ansible/observability] Heal dpkg interruptions before installs

### DIFF
--- a/playbooks/deploy-observability-stack.yml
+++ b/playbooks/deploy-observability-stack.yml
@@ -4,6 +4,12 @@
   become: true
   vars:
     templates_dir: "{{ playbook_dir }}/../templates"
+  pre_tasks:
+    - name: Recover from interrupted dpkg state
+      ansible.builtin.command: dpkg --configure -a
+      register: dpkg_recover
+      changed_when: dpkg_recover.stdout != '' or dpkg_recover.stderr != ''
+      failed_when: dpkg_recover.rc != 0
   tasks:
     - name: Ensure required packages are installed
       ansible.builtin.apt:
@@ -83,6 +89,12 @@
   vars:
     loki_host: "{{ hostvars['ctrl-linux-01'].ansible_host | default('ctrl-linux-01') }}"
     templates_dir: "{{ playbook_dir }}/../templates"
+  pre_tasks:
+    - name: Recover from interrupted dpkg state
+      ansible.builtin.command: dpkg --configure -a
+      register: dpkg_recover
+      changed_when: dpkg_recover.stdout != '' or dpkg_recover.stderr != ''
+      failed_when: dpkg_recover.rc != 0
   tasks:
     - name: Ensure required packages are installed
       ansible.builtin.apt:


### PR DESCRIPTION
## Summary
- ensure both observability deployment plays attempt to recover from interrupted dpkg states before installing packages

## Testing Done
- make setup: not run (not required for this change)
- make lint: not run (not required for this change)
- make test: not run (not required for this change)
- CI: not run (not available in sandbox)

<!-- codex-meta v1
task_id: 0
domain: homeops
iteration: 1
network_mode: off
-->


------
https://chatgpt.com/codex/tasks/task_e_68f540475af4832a869a610035dc6752