### PR TITLE
[ansible/observability] Configure Loki for remote ingestion

### DIFF
--- a/playbooks/deploy-observability-stack.yml
+++ b/playbooks/deploy-observability-stack.yml
@@ -2,8 +2,28 @@
 - name: Deploy observability services on controller
   hosts: controllers
   become: true
+  gather_facts: true
   vars:
     templates_dir: "{{ playbook_dir }}/../templates"
+    loki_config_path: /etc/loki/config.yaml
+    loki_data_dir: /var/lib/loki
+    loki_data_subdirs:
+      - "{{ loki_data_dir }}"
+      - "{{ loki_data_dir }}/wal"
+      - "{{ loki_data_dir }}/index"
+      - "{{ loki_data_dir }}/cache"
+      - "{{ loki_data_dir }}/chunks"
+      - "{{ loki_data_dir }}/compactor"
+    loki_service_user: loki
+    loki_service_group: loki
+    loki_http_scheme: http
+    loki_http_listen_address: "{{ loki_listen_address | default('0.0.0.0') }}"
+    loki_http_port: "{{ (loki_port | default(3100)) | int }}"
+    loki_grpc_port: 9096
+    loki_advertise_host: >-
+      {{ loki_advertise_address | default(
+           ansible_host | default(
+             ansible_default_ipv4.address | default(inventory_hostname))) }}
   pre_tasks:
     - name: Recover from interrupted dpkg state
       ansible.builtin.command: dpkg --configure -a
@@ -52,11 +72,35 @@
         state: present
         update_cache: true
 
+    - name: Ensure Loki data directories exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        owner: "{{ loki_service_user }}"
+        group: "{{ loki_service_group }}"
+        mode: "0750"
+      loop: "{{ loki_data_subdirs }}"
+
+    - name: Deploy Loki configuration
+      ansible.builtin.template:
+        src: "{{ templates_dir }}/loki-config.yaml.j2"
+        dest: "{{ loki_config_path }}"
+        owner: "{{ loki_service_user }}"
+        group: "{{ loki_service_group }}"
+        mode: "0640"
+      notify: Restart Loki
+
     - name: Ensure Loki service is enabled and started
       ansible.builtin.systemd:
         name: loki
         state: started
         enabled: true
+
+    - name: Record Loki connection facts for other hosts
+      ansible.builtin.set_fact:
+        loki_advertise_host: "{{ loki_advertise_host }}"
+        loki_http_port: "{{ loki_http_port | int }}"
+        loki_http_scheme: "{{ loki_http_scheme }}"
 
     - name: Create Grafana datasource directory
       ansible.builtin.file:
@@ -78,6 +122,11 @@
         enabled: true
 
   handlers:
+    - name: Restart Loki
+      ansible.builtin.systemd:
+        name: loki
+        state: restarted
+
     - name: Restart Grafana
       ansible.builtin.systemd:
         name: grafana-server
@@ -87,7 +136,14 @@
   hosts: linux,controllers
   become: true
   vars:
-    loki_host: "{{ hostvars['ctrl-linux-01'].ansible_host | default('ctrl-linux-01') }}"
+    controller_host: "{{ groups['controllers'][0] }}"
+    controller_vars: "{{ hostvars[controller_host] }}"
+    loki_push_scheme: "{{ controller_vars.loki_http_scheme | default('http') }}"
+    loki_push_host: >-
+      {{ 'localhost' if inventory_hostname == controller_host else
+         controller_vars.loki_advertise_host | default(
+           controller_vars.ansible_host | default(controller_host)) }}
+    loki_push_port: "{{ controller_vars.loki_http_port | default(3100) | int }}"
     templates_dir: "{{ playbook_dir }}/../templates"
   pre_tasks:
     - name: Recover from interrupted dpkg state

--- a/templates/config.alloy.j2
+++ b/templates/config.alloy.j2
@@ -6,6 +6,6 @@ loki.source.journal "system" {
 
 loki.write "default" {
   endpoint {
-    url = "http://{{ 'localhost' if inventory_hostname == 'ctrl-linux-01' else loki_host }}:3100/loki/api/v1/push"
+    url = "{{ loki_push_scheme }}://{{ loki_push_host }}:{{ loki_push_port | int }}/loki/api/v1/push"
   }
 }

--- a/templates/loki-config.yaml.j2
+++ b/templates/loki-config.yaml.j2
@@ -1,0 +1,61 @@
+# templates/loki-config.yaml.j2
+# Single-node Loki configuration tailored for HomeOps
+server:
+  http_listen_address: "{{ loki_http_listen_address }}"
+  http_listen_port: {{ loki_http_port | int }}
+  grpc_listen_port: {{ loki_grpc_port | int }}
+
+distributor:
+  ring:
+    kvstore:
+      store: memberlist
+
+ingester:
+  wal:
+    enabled: true
+    dir: {{ loki_data_dir }}/wal
+  lifecycler:
+    address: "{{ loki_advertise_host }}"
+    ring:
+      kvstore:
+        store: memberlist
+      replication_factor: 1
+    final_sleep: 0s
+  chunk_encoding: snappy
+
+memberlist:
+  join_members:
+    - 127.0.0.1
+
+schema_config:
+  configs:
+    - from: 2020-10-15
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: loki_index_
+        period: 24h
+
+storage_config:
+  boltdb_shipper:
+    shared_store: filesystem
+    active_index_directory: {{ loki_data_dir }}/index
+    cache_location: {{ loki_data_dir }}/cache
+  filesystem:
+    directory: {{ loki_data_dir }}/chunks
+
+compactor:
+  working_directory: {{ loki_data_dir }}/compactor
+  shared_store: filesystem
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+chunk_store_config:
+  max_look_back_period: 0s
+
+table_manager:
+  retention_deletes_enabled: true
+  retention_period: 744h


### PR DESCRIPTION
## Summary
- template and deploy a single-node Loki configuration that listens on all interfaces and manages its data directories
- share controller Loki connection details with Alloy targets and update the Alloy template to use the advertised endpoint

Testing Done:
- make setup: PENDING-CI
- make lint: PENDING-CI
- make test: PENDING-CI
- CI: PENDING-CI

<!-- codex-meta v1
task_id: ISSUE-28
domain: homeops
iteration: 1
network_mode: off
-->


------
https://chatgpt.com/codex/tasks/task_e_68f6a2d2245c832aad36fde670a8920c