### PR TITLE
[ci] deploy stack before Gate2 verification

### DIFF
--- a/.github/workflows/pr-quality-check.yml
+++ b/.github/workflows/pr-quality-check.yml
@@ -73,6 +73,11 @@ jobs:
           python -m pip install "ansible-core>=2.16" "ansible-lint>=24.0" "yamllint>=1.32" || true
           echo "$VENV/bin" >> "$GITHUB_PATH"
 
+      - name: Gate2 — make deploy (prepare stack)
+        env:
+          ANSIBLE_STDOUT_CALLBACK: ansible.builtin.yaml
+        run: make deploy
+
       - name: Gate2 — make itest
         env:
           ANSIBLE_STDOUT_CALLBACK: ansible.builtin.yaml
@@ -86,7 +91,7 @@ jobs:
           path: artifacts/itest
           if-no-files-found: ignore
 
-      - name: Deploy (only when explicitly enabled)
+      - name: Redeploy (only when explicitly enabled)
         if: ${{ success() && vars.AUTO_DEPLOY == 'true' }}
         env:
           ANSIBLE_STDOUT_CALLBACK: ansible.builtin.yaml


### PR DESCRIPTION
Summary:
- ensure the gate2-selfhosted workflow runs make deploy before make itest so verification checks an active observability stack
- rename the optional AUTO_DEPLOY step to clarify it is a post-verification redeploy

Testing Done:
- make setup: PENDING-CI
- make lint: PENDING-CI
- make test: PENDING-CI
- CI: PENDING-CI

<!-- codex-meta v1
task_id: ISSUE-45
domain: homeops
iteration: 1
network_mode: on
-->

------
https://chatgpt.com/codex/tasks/task_e_68f6c4bae5c0832a82573b4e78080ed4