### PR TITLE
[ansible/deploy] Retry dpkg recovery when locks block

### DIFF
--- a/playbooks/deploy-observability-stack.yml
+++ b/playbooks/deploy-observability-stack.yml
@@ -24,12 +24,22 @@
       {{ loki_advertise_address | default(
            ansible_host | default(
              ansible_default_ipv4.address | default(inventory_hostname))) }}
+    dpkg_recover_retries: 6
+    dpkg_recover_delay: 10
+    dpkg_lock_retry_rc: 2
+    dpkg_lock_retry_pattern: '(lock|锁)'
   pre_tasks:
     - name: Recover from interrupted dpkg state
       ansible.builtin.command: dpkg --configure -a
       register: dpkg_recover
       changed_when: dpkg_recover.stdout != '' or dpkg_recover.stderr != ''
-      failed_when: dpkg_recover.rc != 0
+      failed_when:
+        - dpkg_recover.rc not in [0, dpkg_lock_retry_rc]
+        - dpkg_recover.rc == dpkg_lock_retry_rc and
+          ((dpkg_recover.stderr | default('')) | regex_search(dpkg_lock_retry_pattern, ignorecase=True)) is none
+      until: dpkg_recover.rc == 0
+      retries: "{{ dpkg_recover_retries | int }}"
+      delay: "{{ dpkg_recover_delay | int }}"
   tasks:
     - name: Ensure required packages are installed
       ansible.builtin.apt:
@@ -145,12 +155,22 @@
            controller_vars.ansible_host | default(controller_host)) }}
     loki_push_port: "{{ controller_vars.loki_http_port | default(3100) | int }}"
     templates_dir: "{{ playbook_dir }}/../templates"
+    dpkg_recover_retries: 6
+    dpkg_recover_delay: 10
+    dpkg_lock_retry_rc: 2
+    dpkg_lock_retry_pattern: '(lock|锁)'
   pre_tasks:
     - name: Recover from interrupted dpkg state
       ansible.builtin.command: dpkg --configure -a
       register: dpkg_recover
       changed_when: dpkg_recover.stdout != '' or dpkg_recover.stderr != ''
-      failed_when: dpkg_recover.rc != 0
+      failed_when:
+        - dpkg_recover.rc not in [0, dpkg_lock_retry_rc]
+        - dpkg_recover.rc == dpkg_lock_retry_rc and
+          ((dpkg_recover.stderr | default('')) | regex_search(dpkg_lock_retry_pattern, ignorecase=True)) is none
+      until: dpkg_recover.rc == 0
+      retries: "{{ dpkg_recover_retries | int }}"
+      delay: "{{ dpkg_recover_delay | int }}"
   tasks:
     - name: Ensure required packages are installed
       ansible.builtin.apt:


### PR DESCRIPTION
## Summary
* Add lock-aware retry variables for the dpkg recovery pre-task in the controller deployment.
* Apply the same guarded retry logic to the Alloy rollout so transient dpkg locks do not abort the playbook.

Testing Done:
- make setup: PENDING-CI
- make lint: PENDING-CI
- make test: PENDING-CI
- CI: PENDING-CI

<!-- codex-meta v1
task_id: issue-47
domain: homeops
iteration: 1
network_mode: on
-->

------
https://chatgpt.com/codex/tasks/task_e_68f94a9182ec832abda07f0a2a220b6b