### PR TITLE
[ansible/observability] harden deploy retries

### DIFF
--- a/playbooks/deploy-observability-stack.yml
+++ b/playbooks/deploy-observability-stack.yml
@@ -28,6 +28,15 @@
     dpkg_recover_delay: 10
     dpkg_lock_retry_rc: 2
     dpkg_lock_retry_pattern: '(lock|锁)'
+    apt_environment:
+      DEBIAN_FRONTEND: noninteractive
+    apt_operation_retries: 5
+    apt_operation_delay: 20
+    apt_operation_timeout: 600
+    apt_lock_timeout: 120
+    download_retries: 5
+    download_delay: 15
+    download_timeout: 60
   pre_tasks:
     - name: Recover from interrupted dpkg state
       ansible.builtin.command: dpkg --configure -a
@@ -40,6 +49,7 @@
       until: dpkg_recover.rc == 0
       retries: "{{ dpkg_recover_retries | int }}"
       delay: "{{ dpkg_recover_delay | int }}"
+      environment: "{{ apt_environment }}"
   tasks:
     - name: Ensure required packages are installed
       ansible.builtin.apt:
@@ -50,6 +60,20 @@
           - gpg
         state: present
         update_cache: true
+        cache_valid_time: 3600
+        timeout: "{{ apt_operation_timeout | int }}"
+        lock_timeout: "{{ apt_lock_timeout | int }}"
+      register: controller_base_packages
+      retries: "{{ apt_operation_retries | int }}"
+      delay: "{{ apt_operation_delay | int }}"
+      until: controller_base_packages is succeeded
+      environment: "{{ apt_environment }}"
+
+    - name: Report controller base package install attempts
+      ansible.builtin.debug:
+        msg: >-
+          Controller package bootstrap succeeded after
+          {{ controller_base_packages.attempts | default(1) }} attempt(s)
 
     - name: Create keyring directory
       ansible.builtin.file:
@@ -62,11 +86,17 @@
         url: https://apt.grafana.com/gpg.key
         dest: /etc/apt/keyrings/grafana.asc
         mode: '0644'
+        timeout: "{{ download_timeout | int }}"
+      register: grafana_key_download
+      retries: "{{ download_retries | int }}"
+      delay: "{{ download_delay | int }}"
+      until: grafana_key_download is succeeded
 
     - name: Convert Grafana GPG key to keyring
       ansible.builtin.command:
         cmd: gpg --dearmor -o /etc/apt/keyrings/grafana.gpg /etc/apt/keyrings/grafana.asc
         creates: /etc/apt/keyrings/grafana.gpg
+      environment: "{{ apt_environment }}"
 
     - name: Add Grafana APT repository
       ansible.builtin.apt_repository:
@@ -81,6 +111,20 @@
           - grafana
         state: present
         update_cache: true
+        cache_valid_time: 3600
+        timeout: "{{ apt_operation_timeout | int }}"
+        lock_timeout: "{{ apt_lock_timeout | int }}"
+      register: controller_observability_packages
+      retries: "{{ apt_operation_retries | int }}"
+      delay: "{{ apt_operation_delay | int }}"
+      until: controller_observability_packages is succeeded
+      environment: "{{ apt_environment }}"
+
+    - name: Report controller observability package install attempts
+      ansible.builtin.debug:
+        msg: >-
+          Controller observability packages succeeded after
+          {{ controller_observability_packages.attempts | default(1) }} attempt(s)
 
     - name: Ensure Loki data directories exist
       ansible.builtin.file:
@@ -159,6 +203,15 @@
     dpkg_recover_delay: 10
     dpkg_lock_retry_rc: 2
     dpkg_lock_retry_pattern: '(lock|锁)'
+    apt_environment:
+      DEBIAN_FRONTEND: noninteractive
+    apt_operation_retries: "{{ controller_vars.apt_operation_retries | default(5) | int }}"
+    apt_operation_delay: "{{ controller_vars.apt_operation_delay | default(20) | int }}"
+    apt_operation_timeout: "{{ controller_vars.apt_operation_timeout | default(600) | int }}"
+    apt_lock_timeout: "{{ controller_vars.apt_lock_timeout | default(120) | int }}"
+    download_retries: "{{ controller_vars.download_retries | default(5) | int }}"
+    download_delay: "{{ controller_vars.download_delay | default(15) | int }}"
+    download_timeout: "{{ controller_vars.download_timeout | default(60) | int }}"
   pre_tasks:
     - name: Recover from interrupted dpkg state
       ansible.builtin.command: dpkg --configure -a
@@ -171,6 +224,7 @@
       until: dpkg_recover.rc == 0
       retries: "{{ dpkg_recover_retries | int }}"
       delay: "{{ dpkg_recover_delay | int }}"
+      environment: "{{ apt_environment }}"
   tasks:
     - name: Ensure required packages are installed
       ansible.builtin.apt:
@@ -181,6 +235,20 @@
           - gpg
         state: present
         update_cache: true
+        cache_valid_time: 3600
+        timeout: "{{ apt_operation_timeout | int }}"
+        lock_timeout: "{{ apt_lock_timeout | int }}"
+      register: linux_base_packages
+      retries: "{{ apt_operation_retries | int }}"
+      delay: "{{ apt_operation_delay | int }}"
+      until: linux_base_packages is succeeded
+      environment: "{{ apt_environment }}"
+
+    - name: Report Linux base package install attempts
+      ansible.builtin.debug:
+        msg: >-
+          Linux host package bootstrap succeeded after
+          {{ linux_base_packages.attempts | default(1) }} attempt(s)
 
     - name: Create keyring directory
       ansible.builtin.file:
@@ -193,11 +261,17 @@
         url: https://apt.grafana.com/gpg.key
         dest: /etc/apt/keyrings/grafana.asc
         mode: '0644'
+        timeout: "{{ download_timeout | int }}"
+      register: grafana_key_download
+      retries: "{{ download_retries | int }}"
+      delay: "{{ download_delay | int }}"
+      until: grafana_key_download is succeeded
 
     - name: Convert Grafana GPG key to keyring
       ansible.builtin.command:
         cmd: gpg --dearmor -o /etc/apt/keyrings/grafana.gpg /etc/apt/keyrings/grafana.asc
         creates: /etc/apt/keyrings/grafana.gpg
+      environment: "{{ apt_environment }}"
 
     - name: Add Grafana APT repository
       ansible.builtin.apt_repository:
@@ -210,6 +284,20 @@
         name: alloy
         state: present
         update_cache: true
+        cache_valid_time: 3600
+        timeout: "{{ apt_operation_timeout | int }}"
+        lock_timeout: "{{ apt_lock_timeout | int }}"
+      register: alloy_install
+      retries: "{{ apt_operation_retries | int }}"
+      delay: "{{ apt_operation_delay | int }}"
+      until: alloy_install is succeeded
+      environment: "{{ apt_environment }}"
+
+    - name: Report Alloy package install attempts
+      ansible.builtin.debug:
+        msg: >-
+          Alloy package install succeeded after
+          {{ alloy_install.attempts | default(1) }} attempt(s)
 
     - name: Create Alloy configuration directory
       ansible.builtin.file:


### PR DESCRIPTION
Summary:
Implemented retry- and timeout-hardened package installs for the observability stack to avoid long-running deploy hangs and added logging to surface retry attempts.

Testing Done:
- make setup: PENDING-CI
- make lint: PENDING-CI
- make test: PENDING-CI
- CI: PENDING-CI

<!-- codex-meta v1
task_id: ISSUE-48
domain: homeops
iteration: 1
network_mode: off
-->

------
https://chatgpt.com/codex/tasks/task_e_68f94ddb6050832a856b71c9dffae58d