### PR TITLE
[ansible/observability] Remove apt timeout parameters

### DIFF
--- a/playbooks/deploy-observability-stack.yml
+++ b/playbooks/deploy-observability-stack.yml
@@ -61,7 +61,6 @@
         state: present
         update_cache: true
         cache_valid_time: 3600
-        timeout: "{{ apt_operation_timeout | int }}"
         lock_timeout: "{{ apt_lock_timeout | int }}"
       register: controller_base_packages
       retries: "{{ apt_operation_retries | int }}"
@@ -112,7 +111,6 @@
         state: present
         update_cache: true
         cache_valid_time: 3600
-        timeout: "{{ apt_operation_timeout | int }}"
         lock_timeout: "{{ apt_lock_timeout | int }}"
       register: controller_observability_packages
       retries: "{{ apt_operation_retries | int }}"
@@ -236,7 +234,6 @@
         state: present
         update_cache: true
         cache_valid_time: 3600
-        timeout: "{{ apt_operation_timeout | int }}"
         lock_timeout: "{{ apt_lock_timeout | int }}"
       register: linux_base_packages
       retries: "{{ apt_operation_retries | int }}"
@@ -285,7 +282,6 @@
         state: present
         update_cache: true
         cache_valid_time: 3600
-        timeout: "{{ apt_operation_timeout | int }}"
         lock_timeout: "{{ apt_lock_timeout | int }}"
       register: alloy_install
       retries: "{{ apt_operation_retries | int }}"


### PR DESCRIPTION
## Summary
- remove the unsupported timeout argument from all ansible.builtin.apt tasks in the observability deployment playbook
- rely on the existing lock_timeout handling to keep package installs resilient without syntax errors

## Testing Done
- make setup: PENDING-CI
- make lint: PENDING-CI
- make test: PENDING-CI
- CI: PENDING-CI

<!-- codex-meta v1
task_id: 51
domain: homeops
iteration: 1
network_mode: on
-->

------
https://chatgpt.com/codex/tasks/task_e_68f95992888c832a8c002457cf5553c7