### PR TITLE
Fix: remove invalid comment from Alloy config template

### DIFF
--- a/templates/config.alloy.j2
+++ b/templates/config.alloy.j2
@@ -1,4 +1,3 @@
-# templates/config.alloy.j2
 loki.source.journal "system" {
   labels = {job = "systemd-journal"}
   forward_to = [loki.write.default.receiver]


### PR DESCRIPTION
## Summary
- remove the leading comment from the Alloy configuration template so the generated config parses correctly

Fixes #59

## Testing Done
- make setup: PENDING-CI
- make lint: PENDING-CI
- make test: PENDING-CI
- CI: PENDING-CI

------
https://chatgpt.com/codex/tasks/task_e_68f993a28414832aa4373bc73f6adce2