### PR TITLE
[ci] Quote workflow triggers for yamllint

### DIFF
--- a/.github/workflows/auto-deploy-observability.yml
+++ b/.github/workflows/auto-deploy-observability.yml
@@ -1,7 +1,7 @@
 ---
 name: Auto-Deploy Observability Stack
 
-on:
+'on':
   push:
     branches:
       - main

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -1,8 +1,8 @@
 ---
 name: Everyone Is Here (System-Wide Health Check)
 
-on:
-  workflow_dispatch:
+'on':
+  workflow_dispatch: {}
 
 jobs:
   health-check:

--- a/.github/workflows/pr-quality-check.yml
+++ b/.github/workflows/pr-quality-check.yml
@@ -1,12 +1,12 @@
 ---
 name: "HomeOps Quality Gates (Option A: venv outside repo)"
 
-on:
+'on':
   push:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 jobs:
   gate1-cloud:

--- a/.github/workflows/run-ansible-playbook.yml
+++ b/.github/workflows/run-ansible-playbook.yml
@@ -1,7 +1,7 @@
 ---
 name: Run Ansible Playbook Manually
 
-on:
+'on':
   workflow_dispatch:
     inputs:
       playbook:

--- a/.github/workflows/test-and-switch.yml
+++ b/.github/workflows/test-and-switch.yml
@@ -1,8 +1,8 @@
 ---
 name: Full Windows Test and Switch to Linux
 
-on:
-  workflow_dispatch:
+'on':
+  workflow_dispatch: {}
 
 jobs:
   test-and-switch:

--- a/.github/workflows/toggle-os.yml
+++ b/.github/workflows/toggle-os.yml
@@ -1,8 +1,8 @@
 ---
 name: Smart Toggle OS
 
-on:
-  workflow_dispatch:
+'on':
+  workflow_dispatch: {}
 
 concurrency:
   group: toggle-os

--- a/.github/workflows/windows-is-here.yml
+++ b/.github/workflows/windows-is-here.yml
@@ -1,8 +1,8 @@
 ---
 name: Windows Is Here (Health Check)
 
-on:
-  workflow_dispatch:
+'on':
+  workflow_dispatch: {}
 
 jobs:
   check-windows:


### PR DESCRIPTION
## Summary
- quote GitHub workflow event keys and explicitly map workflow_dispatch triggers so yamllint no longer flags truthy warnings

## Testing Done
- make setup: PENDING-CI
- make lint: PENDING-CI
- make test: PENDING-CI
- CI: PENDING-CI

<!-- codex-meta v1
task_id: 65
domain: homeops
iteration: 1
network_mode: off
-->

------
https://chatgpt.com/codex/tasks/task_e_68fae3850874832ab1b1f80f1255a9b6