### PR TITLE
refactor: split push and PR workflows

### DIFF
--- a/.github/workflows/auto-deploy-observability.yml
+++ b/.github/workflows/auto-deploy-observability.yml
@@ -1,26 +1,52 @@
 ---
-name: Auto-Deploy Observability Stack
+name: "HomeOps Main Branch Pipeline"
 
 'on':
   push:
     branches:
       - main
-    paths:  # 只有当日志相关的剧本或模板文件发生变化时，才触发
-      - 'playbooks/deploy-observability-stack.yml'
-      - 'templates/config.alloy.j2'
-      - 'templates/grafana-datasource-loki.yml.j2'
+
+concurrency:
+  group: homeops-main-pipeline
+  cancel-in-progress: false
 
 jobs:
-  auto-deploy:
+  gate2-main:
+    name: Gate2 (self-hosted) — deploy & verify
     runs-on: self-hosted
     steps:
-      - name: 1. Checkout code
+      - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: 2. Setup SSH Key
+      - name: Configure SSH credentials
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      - name: 3. Run the observability stack deployment
-        run: ansible-playbook -i inventory/hosts.yaml playbooks/deploy-observability-stack.yml
+      - name: Gate0 — make setup
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: '1'
+        run: make setup
+
+      - name: Show tool versions
+        run: cat artifacts/test/tools_versions.txt
+
+      - name: Gate2 — make deploy
+        env:
+          ANSIBLE_STDOUT_CALLBACK: ansible.builtin.yaml
+        run: make deploy
+
+      - name: Gate2 — make itest
+        env:
+          ANSIBLE_STDOUT_CALLBACK: ansible.builtin.yaml
+        run: make itest
+
+      - name: Upload artifacts (always)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-pipeline-artifacts
+          path: |
+            artifacts/test
+            artifacts/itest
+          if-no-files-found: ignore

--- a/.github/workflows/pr-quality-check.yml
+++ b/.github/workflows/pr-quality-check.yml
@@ -1,12 +1,9 @@
 ---
-name: "HomeOps Quality Gates (Option A: venv outside repo)"
+name: "HomeOps PR Quality Gates"
 
 'on':
-  push:
-    branches: ["main"]
   pull_request:
     branches: ["main"]
-  workflow_dispatch: {}
 
 jobs:
   gate1-cloud:
@@ -49,50 +46,3 @@ jobs:
           name: gate1-artifacts
           path: artifacts/test
           if-no-files-found: warn
-
-  gate2-selfhosted:
-    name: Gate2 (self-hosted) — itest + conditional deploy
-    needs: gate1-cloud
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: self-hosted
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Ensure venv in runner temp
-        shell: bash
-        run: |
-          set -euo pipefail
-          if ! command -v python3 >/dev/null 2>&1; then
-            echo "python3 missing on runner" >&2
-            exit 2
-          fi
-          VENV="${{ runner.temp }}/venv_homeops"
-          python3 -m venv "$VENV" || true
-          . "$VENV/bin/activate" || true
-          python -m pip install -U pip wheel || true
-          python -m pip install "ansible-core>=2.16" "ansible-lint>=24.0" "yamllint>=1.32" || true
-          echo "$VENV/bin" >> "$GITHUB_PATH"
-
-      - name: Gate2 — make deploy (prepare stack)
-        env:
-          ANSIBLE_STDOUT_CALLBACK: ansible.builtin.yaml
-        run: make deploy
-
-      - name: Gate2 — make itest
-        env:
-          ANSIBLE_STDOUT_CALLBACK: ansible.builtin.yaml
-        run: make itest
-
-      - name: Upload itest artifacts (always)
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: itest-artifacts
-          path: artifacts/itest
-          if-no-files-found: ignore
-
-      - name: Redeploy (only when explicitly enabled)
-        if: ${{ success() && vars.AUTO_DEPLOY == 'true' }}
-        env:
-          ANSIBLE_STDOUT_CALLBACK: ansible.builtin.yaml
-        run: make deploy


### PR DESCRIPTION
## Summary
- restrict pr-quality-check to Gate1 validation on pull requests targeting main
- convert the main-branch workflow to run make setup, make deploy, and make itest sequentially on the self-hosted runner

## Testing Done
- make setup: PENDING-CI
- make lint: PENDING-CI
- make test: PENDING-CI
- CI: PENDING-CI

<!-- codex-meta v1
task_id: ISSUE-74
domain: homeops
iteration: 1
network_mode: on
-->

------
https://chatgpt.com/codex/tasks/task_e_68fb2cb496d4832a8734bdba69d2525a