### PR TITLE
[ansible/ci] Vendorize collections for offline setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ make deploy # 条件部署：Gate 2 通过后按需在主干或人工触发（�
 
 对各命令的职责简述
 
-make setup：创建/确认可复现的虚拟环境（.venv/）与 collections，产出 artifacts/test/tools_versions.txt。
+make setup：创建/确认可复现的虚拟环境（.venv/）与 collections，产出 artifacts/test/tools_versions.txt。所有 collections 必须从仓库随附的 `vendor/*.tar.gz` 本地解包（禁止访问 galaxy.ansible.com）。
 
 make lint：静态风格、语法检查，必须限制在仓库源（playbooks/,roles/,inventory/ 等），不得扫入 .venv/ / Runner site-packages。
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,9 @@ $(VENV_MARKER): requirements.txt
 $(COLLECTIONS_MARKER): requirements.yml $(VENV_MARKER)
 	@echo "--- installing Ansible collections into $(abspath $(COLLECTIONS_DIR)) ---"
 	@mkdir -p $(COLLECTIONS_DIR)
-	@$(GALAXY) collection install -r requirements.yml -p $(COLLECTIONS_DIR) --force
+	@echo "--- using vendor archives specified in requirements.yml ---"
+	@cat requirements.yml
+	@$(GALAXY) collection install -r requirements.yml -p $(COLLECTIONS_DIR) --force --offline
 	@touch $@
 
 setup: $(VENV_MARKER) $(COLLECTIONS_MARKER)

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ make itest   # Gate2: 部署+验证组合拳（自托管 Runner，先部署再�
 make deploy  # 正式释放（人工/主干触发）
 ```
 
-**判分权威**：`make itest` 的通过/失败 **只看** [`docs/verification-spec.md`](docs/verification-spec.md)。  
+**判分权威**：`make itest` 的通过/失败 **只看** [`docs/verification-spec.md`](docs/verification-spec.md)。
 **AI 操作手册**：编排规则与提示见 [`AGENTS.md`](AGENTS.md)。
+**离线友好**：`make setup` 会直接从仓库内的 `vendor/*.tar.gz` 解包所需 collections（无需访问 `galaxy.ansible.com`）。
 
 ### 🛤️ CI 跑道分离（云/本地）
 ```mermaid
@@ -86,10 +87,12 @@ flowchart LR
 
 > 以下命令默认在 **自托管运行器**（`ctrl-linux-01`）上执行。
 
-1. **拉起工具链**
+1. **拉起工具链（离线友好）**
    ```bash
    make setup
    ```
+
+   > 运行时会使用仓库随附的 `vendor/*.tar.gz` 来安装 Ansible collections，无需联网。
 
 2. **本地质量门（云端与本地均可）**
    ```bash

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,5 @@
 collections:
-  - name: community.general
-  - name: ansible.windows
+  - name: ./vendor/community-general-11.4.0.tar.gz
+    type: file
+  - name: ./vendor/ansible-windows-3.2.0.tar.gz
+    type: file


### PR DESCRIPTION
Vendorize Ansible collections so that `make setup` relies on the repository's vendored archives and no longer needs to reach galaxy.ansible.com.

Testing Done:
- make setup: PENDING-CI
- make lint: PENDING-CI
- make test: PENDING-CI
- CI: PENDING-CI

<!-- codex-meta v1
task_id: 80
domain: homeops
iteration: 1
network_mode: on
-->

------
https://chatgpt.com/codex/tasks/task_e_68fc5fa6bcc0832a95a54688d015f421