### PR TITLE
[BUGFIX] Ensure Loki service account exists before managing data directories

### DIFF
--- a/playbooks/deploy-observability-stack.yml
+++ b/playbooks/deploy-observability-stack.yml
@@ -464,6 +464,21 @@
       register: dpkg_lock_snapshot_post_packages
       changed_when: false
 
+    - name: Ensure Loki service group exists
+      ansible.builtin.group:
+        name: "{{ loki_service_group }}"
+        state: present
+        system: true
+
+    - name: Ensure Loki service user exists
+      ansible.builtin.user:
+        name: "{{ loki_service_user }}"
+        group: "{{ loki_service_group }}"
+        state: present
+        system: true
+        shell: /usr/sbin/nologin
+        create_home: false
+
     - name: Ensure Loki data directories exist
       ansible.builtin.file:
         path: "{{ item }}"


### PR DESCRIPTION
## Summary
- create the loki system group and user before creating its data directories to prevent ownership failures

## Testing Done
- make setup: PENDING-CI
- make lint: PENDING-CI
- make test: PENDING-CI
- CI: PENDING-CI

<!-- codex-meta v1
task_id: 82
domain: homeops
iteration: 1
network_mode: on
-->

------
https://chatgpt.com/codex/tasks/task_e_68fc63617544832a99543d3d76e3f803