### PR TITLE
[ansible/observability] vendor collections and loki user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(VENV_MARKER): requirements.txt
 	@touch $@
 
 $(COLLECTIONS_MARKER): requirements.yml $(VENV_MARKER)
-	@echo "--- installing Ansible collections into $(abspath $(COLLECTIONS_DIR)) ---"
+	@echo "--- installing Ansible collections from ./vendor into $(abspath $(COLLECTIONS_DIR)) ---"
 	@mkdir -p $(COLLECTIONS_DIR)
 	@$(GALAXY) collection install -r requirements.yml -p $(COLLECTIONS_DIR) --force
 	@touch $@

--- a/playbooks/deploy-observability-stack.yml
+++ b/playbooks/deploy-observability-stack.yml
@@ -464,6 +464,20 @@
       register: dpkg_lock_snapshot_post_packages
       changed_when: false
 
+    - name: Ensure Loki group exists
+      ansible.builtin.group:
+        name: "{{ loki_service_group }}"
+        system: true
+
+    - name: Ensure Loki user exists
+      ansible.builtin.user:
+        name: "{{ loki_service_user }}"
+        system: true
+        shell: /usr/sbin/nologin
+        home: "{{ loki_data_dir }}"
+        create_home: false
+        group: "{{ loki_service_group }}"
+
     - name: Ensure Loki data directories exist
       ansible.builtin.file:
         path: "{{ item }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,7 @@
 collections:
   - name: community.general
+    source: ./vendor/community-general-11.4.0.tar.gz
+    type: file
   - name: ansible.windows
+    source: ./vendor/ansible-windows-3.2.0.tar.gz
+    type: file


### PR DESCRIPTION
Summary:
Vendorized the required Galaxy collections to install from the checked-in tarballs and provision the Loki system account before creating its data directories.

Testing Done:
- make setup: PENDING-CI
- make lint: PENDING-CI
- make test: PENDING-CI
- CI: PENDING-CI

<!-- codex-meta v1
task_id: issue-85
domain: homeops
iteration: 1
network_mode: on
-->


------
https://chatgpt.com/codex/tasks/task_e_68fc6e698764832a89a6a39951fa4bf0