### PR TITLE
[ansible/observability] Harden Gate2 offline flow

### DIFF
--- a/.github/workflows/auto-deploy-observability.yml
+++ b/.github/workflows/auto-deploy-observability.yml
@@ -23,14 +23,6 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      - name: Gate0 — make setup
-        env:
-          PIP_DISABLE_PIP_VERSION_CHECK: '1'
-        run: make setup
-
-      - name: Show tool versions
-        run: cat artifacts/test/tools_versions.txt
-
       - name: Gate2 — make itest (deploy & verify)
         env:
           ANSIBLE_STDOUT_CALLBACK: ansible.builtin.yaml

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ $(VENV_MARKER): requirements.txt
 $(COLLECTIONS_MARKER): requirements.yml $(VENV_MARKER)
 	@echo "--- installing Ansible collections from ./vendor into $(abspath $(COLLECTIONS_DIR)) ---"
 	@mkdir -p $(COLLECTIONS_DIR)
-	@$(GALAXY) collection install -r requirements.yml -p $(COLLECTIONS_DIR) --force
+	@$(GALAXY) collection install -r requirements.yml -p $(COLLECTIONS_DIR) --force --offline
 	@touch $@
 
 setup: $(VENV_MARKER) $(COLLECTIONS_MARKER)

--- a/playbooks/deploy-observability-stack.yml
+++ b/playbooks/deploy-observability-stack.yml
@@ -542,6 +542,7 @@
   hosts: linux,controllers
   become: true
   serial: 1
+  ignore_unreachable: true
   vars:
     deploy_artifacts_dir: "{{ hostvars['localhost'].deploy_artifacts_dir | default('artifacts/itest') }}"
     controller_host: "{{ groups['controllers'][0] }}"

--- a/playbooks/tests/verify_observability.yml
+++ b/playbooks/tests/verify_observability.yml
@@ -115,6 +115,32 @@
           ansible.builtin.fail:
             msg: "Grafana health endpoint check failed; see artifacts/grafana_health_response.json for details."
 
+    - name: Check Grafana Loki datasource file metadata
+      ansible.builtin.stat:
+        path: /etc/grafana/provisioning/datasources/loki.yml
+      register: grafana_datasource_stat
+
+    - name: Assert Grafana Loki datasource file exists
+      ansible.builtin.assert:
+        that:
+          - grafana_datasource_stat.stat.exists
+          - not grafana_datasource_stat.stat.isdir
+        fail_msg: "Grafana Loki datasource definition missing at /etc/grafana/provisioning/datasources/loki.yml"
+
+    - name: Confirm Grafana Loki datasource references Loki type
+      ansible.builtin.command:
+        cmd: >-
+          grep -F 'type: loki' /etc/grafana/provisioning/datasources/loki.yml
+      register: grafana_datasource_check
+      changed_when: false
+
+    - name: Record Grafana datasource verification snippet
+      ansible.builtin.copy:
+        dest: "{{ artifacts_dir }}/{{ inventory_hostname }}_grafana_datasource_check.log"
+        content: "{{ grafana_datasource_check.stdout | default('') }}\n"
+        mode: "0644"
+      delegate_to: localhost
+
     - name: Query Loki for systemd journal logs
       block:
         - name: Request Loki log query results


### PR DESCRIPTION
## Summary
- enforce offline Ansible collection installs when bootstrapping the toolchain
- streamline the main-branch deploy workflow to rely on the composite `make itest`
- tolerate unreachable Linux nodes during Alloy deploys and safely verify Grafana's Loki datasource

## Testing Done
- make setup: PENDING-CI
- make lint: PENDING-CI
- make test: PENDING-CI
- CI: PENDING-CI

<!-- codex-meta v1
task_id: 90
domain: homeops
iteration: 1
network_mode: on
-->


------
https://chatgpt.com/codex/tasks/task_e_68fd70ffc7f8832a9d0002429423fe30