### PR TITLE
[ansible/tests] capture Loki journal when service assertion fails

### DIFF
--- a/playbooks/tests/tasks/verify_required_service.yaml
+++ b/playbooks/tests/tasks/verify_required_service.yaml
@@ -1,0 +1,42 @@
+---
+- name: Verify required service state
+  block:
+    - name: Verify service state and enablement
+      ansible.builtin.assert:
+        that:
+          - "required_service.unit in ansible_facts.services"
+          - "ansible_facts.services[required_service.unit].state == 'running'"
+          - >-
+            (ansible_facts.services[required_service.unit].status is defined
+             and ansible_facts.services[required_service.unit].status == 'enabled')
+            or (ansible_facts.services[required_service.unit].enabled is defined
+                and ansible_facts.services[required_service.unit].enabled)
+        fail_msg: >-
+          Service {{ required_service.friendly }} must be running and enabled on controller {{ inventory_hostname }}
+        success_msg: >-
+          Service {{ required_service.friendly }} running and enabled on controller {{ inventory_hostname }}
+  rescue:
+    - name: Collect Loki service journal after assertion failure
+      ansible.builtin.command:
+        cmd: journalctl -u loki.service --no-pager -n 200
+      register: loki_journal_capture
+      changed_when: false
+      failed_when: false
+      when: required_service.unit == 'loki.service'
+
+    - name: Write Loki service journal artifact
+      ansible.builtin.copy:
+        dest: "{{ artifacts_dir }}/{{ inventory_hostname }}_loki_journal.log"
+        content: |-
+          {{ loki_journal_capture.stdout | default('') }}
+          {% if loki_journal_capture.stderr is defined and loki_journal_capture.stderr | length > 0 %}
+          --- stderr ---
+          {{ loki_journal_capture.stderr }}
+          {% endif %}
+        mode: "0644"
+      delegate_to: localhost
+      when: required_service.unit == 'loki.service'
+
+    - name: Fail after required service assertion failure
+      ansible.builtin.fail:
+        msg: "{{ ansible_failed_result.msg | default('Service verification failed; see Loki journal artifact for details.') }}"

--- a/playbooks/tests/verify_observability.yml
+++ b/playbooks/tests/verify_observability.yml
@@ -42,20 +42,11 @@
       delegate_to: localhost
 
     - name: Assert required services are running and enabled
-      ansible.builtin.assert:
-        that:
-          - "item.unit in ansible_facts.services"
-          - "ansible_facts.services[item.unit].state == 'running'"
-          - >-
-            (ansible_facts.services[item.unit].status is defined
-             and ansible_facts.services[item.unit].status == 'enabled')
-            or (ansible_facts.services[item.unit].enabled is defined
-                and ansible_facts.services[item.unit].enabled)
-        fail_msg: "Service {{ item.friendly }} must be running and enabled on controller {{ inventory_hostname }}"
-        success_msg: "Service {{ item.friendly }} running and enabled on controller {{ inventory_hostname }}"
+      ansible.builtin.include_tasks: tasks/verify_required_service.yaml
       loop: "{{ required_services }}"
       loop_control:
-        label: "{{ item.unit }}"
+        loop_var: required_service
+        label: "{{ required_service.unit }}"
 
     - name: Probe Loki readiness endpoint
       block:


### PR DESCRIPTION
## Summary
- wrap the controller service verification in a reusable task include so we can attach failure handling
- collect loki.service journal output into artifacts when the assertion fails and surface the original error message

## Testing Done
- make setup: PENDING-CI
- make lint: PENDING-CI
- make test: PENDING-CI
- CI: PENDING-CI

<!-- codex-meta v1
task_id: ISSUE-93
domain: homeops
iteration: 1
network_mode: on
-->

------
https://chatgpt.com/codex/tasks/task_e_68fd760aa3f0832aa3c0c39d877fc622