### PR TITLE
[ansible/tests] Retry Loki readiness probe during verification

### DIFF
--- a/playbooks/tests/verify_observability.yml
+++ b/playbooks/tests/verify_observability.yml
@@ -58,6 +58,9 @@
             status_code: 200
             timeout: 10
           register: loki_ready
+          until: loki_ready.status | default(0) == 200
+          retries: 10
+          delay: 5
 
         - name: Write Loki readiness response
           ansible.builtin.copy:


### PR DESCRIPTION
Summary:
- Add retries and delay to the Loki readiness probe in Gate 2 verification so the check tolerates the ingester warm-up period before reporting success.

Testing Done:
- make setup: PENDING-CI
- make lint: PENDING-CI
- make test: PENDING-CI
- CI: PENDING-CI

<!-- codex-meta v1
task_id: ISSUE-102
domain: homeops
iteration: 1
network_mode: on
-->

------
https://chatgpt.com/codex/tasks/task_e_68fdb4760dc8832aaa80c89fb6298ece